### PR TITLE
Add python3.7 testing to travis testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,5 +6,9 @@ python:
   - "3.4"
   - "3.5"
   - "3.6"
+matrix:
+  include:
+    - { python: 3.7, dist: xenial, sudo: true }
+
 install: python setup.py install
 script: python -m unittest discover


### PR DESCRIPTION
Added inside "include" section to avoid using containers except when necessary.

Extra flags can be removed later if travis moves to containers for more recent debian releases, see travis-ci/travis-ci#9069 for more information.

This completes part of #11, but keeping a reminder to remove extra flags pending later updates may be useful.