### PR TITLE
Correct dist creation for 1.1.0

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,11 +1,12 @@
-include INSTALL LICENSE README VERSION
-include ReadMe.html history.html
+include INSTALL LICENSE VERSION
+include README.md USAGE.md history.md
 include setup.py prober.py
 include posix_ipc_module.c
 recursive-include prober *.c
-recursive-include demo *.h *.c *.py *.sh *.png *.txt
-recursive-include demo2 *.py *.txt *.png
-recursive-include demo3 *.py *.txt
-recursive-include demo4 *.py *.txt
+recursive-include demo *.h *.c *.py *.sh *.png *.txt *.md
+recursive-include demo2 *.py *.txt *.png *.md
+recursive-include demo3 *.py *.txt *.md
+recursive-include demo4 *.py *.txt *.md
+recursive-include demo5 *.py *.txt *.md
 recursive-include tests *
 global-exclude *.pyc

--- a/USAGE.md
+++ b/USAGE.md
@@ -366,7 +366,7 @@ python -m unittest discover
 
 ### Sample Code
 
-This module comes with four demonstrations. The first (in the directory `demo`) shows how to use shared memory and semaphores. The second (in the directory `demo2`) shows how to use message queues. The third (`demo3`) shows how to use message queue notifications. The fourth (`demo4`) shows how to use a semaphore in a context manager.
+This module comes with five demonstrations. The first (in the directory `demo`) shows how to use shared memory and semaphores. The second (in the directory `demo2`) shows how to use message queues. The third (`demo3`) shows how to use message queue notifications. The fourth (`demo4`) shows how to use a semaphore in a context manager. The fifth (`demo5`) demonstrates use of message queues in combination with Python's `selectors` module.
 
 ### Nobody Likes a Mr. Messy
 


### PR DESCRIPTION
Fix some errors in `MANIFEST.in` that resulted in an incomplete distribution tarball. The incomplete tarball was never distributed; I noticed the error while preparing to release 1.1.0.