### PR TITLE
feature: enable overriding system probe

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,22 @@ Or you can clone the project and install it using `setup.py`:
 
 	python setup.py install
 
+## Cross compiling
+
+In the event of building this library in a cross environment the way `setup.py` probes the build system will likely cause problems.
+The behavior can be changed with two environment variables:
+
+* SKIP_BUILDSYSTEM_PROBE
+	- which skips the probe all togheter, this will require you to manually create a `probe_results.h` file ahead of running setuptools, see `probe_results_template.h`
+* LINK_WITH_RT
+	- set this variable to force compiling with `-lrt`
+
+A example of setting up an environment for cross compilation:
+
+```bash
+$ SKIP_BUILDSYSTEM_PROBE=1 LINK_WITH_RT=1 pip install .
+```
+
 ## License
 
 `posix_ipc` is free software (free as in speech and free as in beer) released under a 3-clause BSD license. Complete licensing information is available in [the LICENSE file](LICENSE).

--- a/probe_results_template.h
+++ b/probe_results_template.h
@@ -1,0 +1,16 @@
+/*
+ * This file can be used as a starting point for creating a probe_results.h file,
+ * in the case where probing the build system is not desirable, such as cross compile environment.
+ * In order to skip the probe and use a manually created probe_results.h set the env var SKIP_BUILDSYSTEM_PROBE
+*/
+
+#define POSIX_IPC_VERSION	"1.1.x"
+#define SEM_GETVALUE_EXISTS
+#define SEM_TIMEDWAIT_EXISTS
+#define MESSAGE_QUEUE_SUPPORT_EXISTS
+#define QUEUE_MESSAGES_MAX_DEFAULT 10
+#define QUEUE_MESSAGE_SIZE_MAX_DEFAULT 8192
+#define QUEUE_PRIORITY_MAX 32767U
+#ifndef PAGE_SIZE
+#define PAGE_SIZE 4096
+#endif

--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,8 @@ try:
 except ImportError:
     import distutils.core as distutools
 
+import os
+
 # My modules
 import prober
 
@@ -41,12 +43,15 @@ license = "http://creativecommons.org/licenses/BSD/"
 keywords = "ipc inter-process communication semaphore shared memory shm message queue"
 
 libraries = []
-
-d = prober.probe()
+d = {}
+# do note that setting the env flag SKIP_BUILDSYSTEM_PROBE will require you
+# to generate a probe_results.h file
+if not os.environ.get('SKIP_BUILDSYSTEM_PROBE'):
+    d = prober.probe()
 
 # Linux & FreeBSD require linking against the realtime libs
 # This causes an error on other platforms
-if "REALTIME_LIB_IS_NEEDED" in d:
+if "REALTIME_LIB_IS_NEEDED" in d or os.environ.get('LINK_WITH_RT'):
     libraries.append("rt")
 
 ext_modules = [distutools.Extension("posix_ipc",


### PR DESCRIPTION
I'm involved in a project that is looking at using posix-ipc in a cross build environment. In the buildsystem we're using (yocto) the probe.py causes some problems, where the host (x86) does not have the same capabilities as the target (arm64).
It feels a bit hacky relying on env vars, but I couldn't really see any less intrusive way of making the probe conditional. I targeted master as it's a few commits ahead of develop, not sure if you want PR's submitted to develop anyway.

Let me know if there are any cleanups or if there is another prefered way of achieving this you'd rather see.