### PR TITLE
Use default cc from environment variable

### DIFF
--- a/prober.py
+++ b/prober.py
@@ -85,7 +85,7 @@ def compile_and_run(filename, linker_options=""):
         s = subprocess.Popen(["./prober/foo"],
                              stdout=subprocess.PIPE).communicate()[0]
         return s.strip().decode()
-    except:
+    except Exception:
         # execution resulted in an error
         return None
 

--- a/prober.py
+++ b/prober.py
@@ -59,7 +59,8 @@ def does_build_succeed(filename, linker_options=""):
     #   - Some versions of Linux place the sem_xxx() functions in libpthread.
     #     Rather than testing whether or not it's needed, I just specify it
     #     everywhere since it's harmless to specify it when it's not needed.
-    cmd = "cc -Wall -o ./prober/foo ./prober/%s %s -lpthread" % (filename, linker_options)
+    cc = os.getenv("CC", "cc")
+    cmd = "%s -Wall -o ./prober/foo ./prober/%s %s -lpthread" % (cc, filename, linker_options)
 
     p = subprocess.Popen(cmd, shell=True, stdout=STDOUT, stderr=STDERR)
 
@@ -71,17 +72,22 @@ def does_build_succeed(filename, linker_options=""):
 def compile_and_run(filename, linker_options=""):
     # Utility function that returns the stdout output from running the
     # compiled source file; None if the compile fails.
-    cmd = "cc -Wall -o ./prober/foo %s ./prober/%s" % (linker_options, filename)
+    cc = os.getenv("CC", "cc")
+    cmd = "%s -Wall -o ./prober/foo %s ./prober/%s" % (cc, linker_options, filename)
 
     p = subprocess.Popen(cmd, shell=True, stdout=STDOUT, stderr=STDERR)
 
     if p.wait():
         # uh-oh, compile failed
         return None
-    else:
+    
+    try:
         s = subprocess.Popen(["./prober/foo"],
                              stdout=subprocess.PIPE).communicate()[0]
         return s.strip().decode()
+    except:
+        # execution resulted in an error
+        return None
 
 
 def get_sysctl_value(name):


### PR DESCRIPTION
In case the system uses a custom c compiler instead of cc (e.g. for cross-compiling), probing system features can fail or can misidentify the features due to the incorrect C compiler.

Instead of using only "cc" for probing features, check if the CC environment variable has a custom C compiler set. If it is present, use that instead of "cc". If it is not present, fall back to "cc".