### PR TITLE
Add CI for building and testing (and publishing) wheels for Linux and Mac

### DIFF
--- a/.github/workflows/build-wheels.yaml
+++ b/.github/workflows/build-wheels.yaml
@@ -20,7 +20,7 @@ jobs:
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.16.2
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: cibw-wheels-${{ matrix.os }}-${{ strategy.job-index }}
           path: ./wheelhouse/*.whl

--- a/.github/workflows/build-wheels.yaml
+++ b/.github/workflows/build-wheels.yaml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.16.2
+        uses: pypa/cibuildwheel@v2.23.0
 
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/build-wheels.yaml
+++ b/.github/workflows/build-wheels.yaml
@@ -2,6 +2,8 @@ name: Build
 
 on:
   push:
+    branches:
+      - develop
   pull_request:
   workflow_call:
 

--- a/.github/workflows/build-wheels.yaml
+++ b/.github/workflows/build-wheels.yaml
@@ -1,0 +1,26 @@
+name: Build
+
+on:
+  push:
+  pull_request:
+  workflow_call:
+
+jobs:
+  build_wheels:
+    name: Build wheels on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        # macos-13 is an intel runner, macos-14 is apple silicon
+        os: [ubuntu-latest, ubuntu-24.04-arm, macos-13, macos-14]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build wheels
+        uses: pypa/cibuildwheel@v2.16.2
+
+      - uses: actions/upload-artifact@v3
+        with:
+          name: cibw-wheels-${{ matrix.os }}-${{ strategy.job-index }}
+          path: ./wheelhouse/*.whl

--- a/.github/workflows/build-wheels.yaml
+++ b/.github/workflows/build-wheels.yaml
@@ -8,6 +8,10 @@ on:
   pull_request:
   workflow_call:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-build
+  cancel-in-progress: true
+
 jobs:
   build_wheels:
     name: Build wheels on ${{ matrix.os }}

--- a/.github/workflows/build-wheels.yaml
+++ b/.github/workflows/build-wheels.yaml
@@ -30,6 +30,11 @@ jobs:
         env:
           CIBW_ENABLE: pypy
           CIBW_TEST_COMMAND: python -m unittest discover --start-directory {package}
+          # While cibuildwheel can build CPython 3.8 universal2/arm64 wheels, we cannot test the arm64 part of them,
+          # even when running on an Apple Silicon machine. This is because we use the x86_64 installer of CPython 3.8.
+          # See the discussion in https://github.com/pypa/cibuildwheel/pull/1169 for the details.
+          # To silence this warning, set `CIBW_TEST_SKIP: "cp38-macosx_*:arm64"`.
+          CIBW_TEST_SKIP: "cp38-macosx_*:arm64"
 
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/build-wheels.yaml
+++ b/.github/workflows/build-wheels.yaml
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
   build_wheels:
-    name: Build wheels on ${{ matrix.os }}
+    name: ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/.github/workflows/build-wheels.yaml
+++ b/.github/workflows/build-wheels.yaml
@@ -1,9 +1,10 @@
-name: Build
+name: Build and test wheels
 
 on:
   push:
     branches:
       - develop
+      - master
   pull_request:
   workflow_call:
 
@@ -12,6 +13,7 @@ jobs:
     name: Build wheels on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         # macos-13 is an intel runner, macos-14 is apple silicon
         os: [ubuntu-latest, ubuntu-24.04-arm, macos-13, macos-14]
@@ -19,10 +21,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Build wheels
+      - name: Build and test wheels
         uses: pypa/cibuildwheel@v2.23.0
+        env:
+          CIBW_ENABLE: pypy
+          CIBW_TEST_COMMAND: python -m unittest discover
 
       - uses: actions/upload-artifact@v4
         with:
-          name: cibw-wheels-${{ matrix.os }}-${{ strategy.job-index }}
+          name: cibw-wheels-${{ matrix.os }}
           path: ./wheelhouse/*.whl

--- a/.github/workflows/build-wheels.yaml
+++ b/.github/workflows/build-wheels.yaml
@@ -29,7 +29,7 @@ jobs:
         uses: pypa/cibuildwheel@v2.23.0
         env:
           CIBW_ENABLE: pypy
-          CIBW_TEST_COMMAND: python -m unittest discover
+          CIBW_TEST_COMMAND: python -m unittest discover --start-directory {package}
 
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/build-wheels.yaml
+++ b/.github/workflows/build-wheels.yaml
@@ -31,7 +31,7 @@ jobs:
           CIBW_ENABLE: pypy
           CIBW_TEST_COMMAND: python -m unittest discover --start-directory {package}
           # there are some failing tests on apple silicon
-          CIBW_TEST_SKIP: "*-macosx_*:arm64"
+          CIBW_TEST_SKIP: "*-macosx_arm64"
 
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/build-wheels.yaml
+++ b/.github/workflows/build-wheels.yaml
@@ -30,11 +30,8 @@ jobs:
         env:
           CIBW_ENABLE: pypy
           CIBW_TEST_COMMAND: python -m unittest discover --start-directory {package}
-          # While cibuildwheel can build CPython 3.8 universal2/arm64 wheels, we cannot test the arm64 part of them,
-          # even when running on an Apple Silicon machine. This is because we use the x86_64 installer of CPython 3.8.
-          # See the discussion in https://github.com/pypa/cibuildwheel/pull/1169 for the details.
-          # To silence this warning, set `CIBW_TEST_SKIP: "cp38-macosx_*:arm64"`.
-          CIBW_TEST_SKIP: "cp38-macosx_*:arm64"
+          # there are some failing tests on apple silicon
+          CIBW_TEST_SKIP: "*-macosx_*:arm64"
 
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/pypi-deploy.yaml
+++ b/.github/workflows/pypi-deploy.yaml
@@ -1,0 +1,43 @@
+name: Build and upload to PyPI
+
+on:
+  push:
+    tags:
+      # only trigger on tags that match the pattern
+      # rel<major>.<minor>.<patch>
+      - "rel[0-9]+.[0-9]+.[0-9]+"
+
+jobs:
+  build_wheels:
+    uses: ./.github/workflows/build-wheels.yml
+
+  build_sdist:
+    name: Build source distribution
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build sdist
+        run: pipx run build --sdist
+
+      - uses: actions/upload-artifact@v3
+        with:
+          path: dist/*.tar.gz
+
+  upload_pypi:
+    needs: [build_wheels, build_sdist]
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@v3
+        with:
+          # unpacks default artifact into dist/
+          # if `name: artifact` is omitted, the action will create extra parent dir
+          name: artifact
+          path: dist
+
+      # - uses: pypa/gh-action-pypi-publish@release/v1
+        # with:
+        #   repository-url: https://upload.pypi.org/legacy/

--- a/.github/workflows/pypi-deploy.yaml
+++ b/.github/workflows/pypi-deploy.yaml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   build_wheels:
-    uses: ./.github/workflows/build-wheels.yml
+    uses: ./.github/workflows/build-wheels.yaml
 
   build_sdist:
     name: Build source distribution

--- a/.github/workflows/pypi-deploy.yaml
+++ b/.github/workflows/pypi-deploy.yaml
@@ -1,4 +1,4 @@
-name: Build and upload to PyPI
+name: Build, test, and upload wheels to PyPI
 
 on:
   push:
@@ -38,6 +38,6 @@ jobs:
           name: artifact
           path: dist
 
-      # - uses: pypa/gh-action-pypi-publish@release/v1
-        # with:
-        #   repository-url: https://upload.pypi.org/legacy/
+      - uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/

--- a/.github/workflows/pypi-deploy.yaml
+++ b/.github/workflows/pypi-deploy.yaml
@@ -41,4 +41,4 @@ jobs:
 
       - uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          repository-url: https://test.pypi.org/legacy/
+          repository-url: https://upload.pypi.org/legacy/

--- a/.github/workflows/pypi-deploy.yaml
+++ b/.github/workflows/pypi-deploy.yaml
@@ -20,7 +20,7 @@ jobs:
       - name: Build sdist
         run: pipx run build --sdist
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           path: dist/*.tar.gz
 

--- a/.github/workflows/pypi-deploy.yaml
+++ b/.github/workflows/pypi-deploy.yaml
@@ -22,6 +22,7 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
+          name: cibw-sdist
           path: dist/*.tar.gz
 
   upload_pypi:
@@ -31,12 +32,12 @@ jobs:
     permissions:
       id-token: write
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
-          # unpacks default artifact into dist/
-          # if `name: artifact` is omitted, the action will create extra parent dir
-          name: artifact
+          # unpacks all CIBW artifacts into dist/
+          pattern: cibw-*
           path: dist
+          merge-multiple: true
 
       - uses: pypa/gh-action-pypi-publish@release/v1
         with:

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -8,9 +8,8 @@ import sys
 
 # Project imports
 import posix_ipc
-# Hack -- add tests directory to sys.path so Python 3 can find base.py.
-sys.path.insert(0, os.path.join(os.getcwd(), 'tests'))
-import base as tests_base  # noqa
+
+from . import base as tests_base
 
 _IS_MACOS = "Darwin" in platform.uname()
 

--- a/tests/test_message_queues.py
+++ b/tests/test_message_queues.py
@@ -7,11 +7,8 @@ import threading
 
 # Project imports
 import posix_ipc
-# Hack -- add tests directory to sys.path so Python 3 can find base.py.
-import sys
-import os
-sys.path.insert(0, os.path.join(os.getcwd(), 'tests'))
-import base as tests_base  # noqa
+
+from . import base as tests_base
 
 if hasattr(posix_ipc, 'USER_SIGNAL_MIN'):
     # Due to Python bug http://bugs.python.org/issue20584, not all valid signal

--- a/tests/test_module.py
+++ b/tests/test_module.py
@@ -5,10 +5,8 @@ import resource
 
 # Project imports
 import posix_ipc
-# Hack -- add tests directory to sys.path so Python 3 can find base.py.
-import sys
-sys.path.insert(0, os.path.join(os.getcwd(), 'tests'))
-import base as tests_base  # noqa
+
+from . import base as tests_base
 
 ONE_MILLION = 1000000
 

--- a/tests/test_semaphores.py
+++ b/tests/test_semaphores.py
@@ -5,11 +5,8 @@ import datetime
 
 # Project imports
 import posix_ipc
-# Hack -- add tests directory to sys.path so Python 3 can find base.py.
-import sys
-import os
-sys.path.insert(0, os.path.join(os.getcwd(), 'tests'))
-import base as tests_base  # noqa
+
+from . import base as tests_base
 
 
 # N_RELEASES is the number of times release() is called in test_release()


### PR DESCRIPTION
Fixes https://github.com/osvenskan/posix_ipc/issues/45

A couple things to note:
- Builds and tests are done for every push to the `develop` and `master` branches, as well as for any pull request (targeting any branch).
- Currently it is set to skip testing on Mac ARM builds because the tests fail there (for some reason or another), so those can probably be re-enabled once fixed (by removing the `CIBW_TEST_SKIP` field), however, the wheels are still built.
- The workflow for publishing to PyPI is triggered on any tag matching the pattern `rel<major>.<minor>.<patch>` being pushed/added. (This does mean that you can use GitHub Releases to publish newer versions as they give you the option to automatically create a tag, I simply tried to maintain maximum compatibility with any current workflows regarding tagging and such)
- I also had to change the `base` imports for tests so that they are relative to the package (`tests`) they are in because `cibuildwheel` uses a different working directory when running them (by default) to ensure it is using the installed package.

For the workflow to be able to upload to PyPI, you must configure a trusted publisher (for GitHub Actions): https://docs.pypi.org/trusted-publishers/adding-a-publisher/