### PR TITLE
require setuptools >= 77.0.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,8 @@
 [build-system]
-requires = ["setuptools"]
+# setuptools ≥ 77.0.3 is required to read SPDX expressions in the license
+# field. Non-SPDX expressions raise a deprecation warning in some contexts.
+# https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license-and-license-files
+requires = ["setuptools >= 77.0.3"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -8,7 +11,7 @@ dynamic = ["version"]
 authors = [{name = "Philip Semanchuk", email = "philip@semanchuk.com"}]
 description = "POSIX IPC primitives (semaphores, shared memory and message queues) for Python"
 readme = "README.md"
-license = {file = "LICENSE"}
+license = "BSD-3-Clause"
 classifiers = [
 	"Development Status :: 5 - Production/Stable",
 	"Intended Audience :: Developers",


### PR DESCRIPTION
Require `setuptools` >= 77.0.3 so I can end headaches with how to specify the license in `pyproject.toml`. Older versions don't like SPDX expressions, newer versions complain that the older style of expressing the license is deprecated. I can't figure out a way to please both old and new `setuptools`, so I'm placing my bets with the future.

https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license-and-license-files