### PR TITLE
remove `license` specification from `pyproject.toml`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,6 @@ dynamic = ["version"]
 authors = [{name = "Philip Semanchuk", email = "philip@semanchuk.com"}]
 description = "POSIX IPC primitives (semaphores, shared memory and message queues) for Python"
 readme = "README.md"
-license = {file = "LICENSE"}
 classifiers = [
 	"Development Status :: 5 - Production/Stable",
 	"Intended Audience :: Developers",


### PR DESCRIPTION
See https://github.com/osvenskan/posix_ipc/issues/68. This is a mitigation for now. It might end up being the "permanent" fix, but I'll probably need to wait a year or three to see what the landscape looks like. That fits right into my lackadaisical update cadence for this project. 