### PR TITLE
specify license in setup.py to improve metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "posix_ipc"
-dynamic = ["version"]
+dynamic = ["version", "license"]
 authors = [{name = "Philip Semanchuk", email = "philip@semanchuk.com"}]
 description = "POSIX IPC primitives (semaphores, shared memory and message queues) for Python"
 readme = "README.md"

--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,10 @@ import sys
 sys.path.append('.')
 import build_support.discover_system_info
 
+# As of April 2025, specifying the license metadata here (rather than in pyproject.toml) seems
+# like the best solution for now. See https://github.com/osvenskan/posix_ipc/issues/68
+LICENSE = "BSD-3-Clause"
+
 # As of April 2025, use of tool.setuptools.ext-modules is stil experimental in pyproject.toml.
 # Also, this code needs to dynamically adjust the `libraries` value that's passed to setuptools,
 # so I can't get rid of setup.py just yet.
@@ -31,4 +35,6 @@ ext_modules = [Extension("posix_ipc",
                          # extra_compile_args=['-E'],
                          )]
 
-setuptools.setup(ext_modules=ext_modules)
+setuptools.setup(ext_modules=ext_modules,
+                 license=LICENSE,
+                 )


### PR DESCRIPTION
Specify license in `setup.py` to improve metadata as suggested by @mara004 here: https://github.com/osvenskan/posix_ipc/issues/68#issuecomment-2800342362

This does indeed make the license visible when running `pip show posix_ipc`.

