### PR TITLE
fix cross compiling failed

### DIFF
--- a/build_support/discover_system_info.py
+++ b/build_support/discover_system_info.py
@@ -84,7 +84,7 @@ def compile_and_run(filename, linker_options=""):
     try:
         s = subprocess.Popen(["./build_support/src/foo"],
                              stdout=subprocess.PIPE).communicate()[0]
-        return s.strip().decode()
+        return s.strip().decode() or None
     except Exception:
         # execution resulted in an error
         return None


### PR DESCRIPTION
In source code:
{code}
.../build_support/discover_system_info.py...
    if does_build_succeed("sniff_mq_prio_max.c"):
        max_priority = compile_and_run("sniff_mq_prio_max.c")

    if max_priority:
        try:
            max_priority = int(max_priority)
        except ValueError:
            max_priority = None

    if max_priority is None:
        # Looking for a #define didn't work; ask sysconf() instead.
        # Note that sys.sysconf_names doesn't exist under Cygwin.
        if hasattr(os, "sysconf_names") and \
           ("SC_MQ_PRIO_MAX" in os.sysconf_names):
            max_priority = os.sysconf("SC_MQ_PRIO_MAX")
        else:
            max_priority = DEFAULT_PRIORITY_MAX
            print_bad_news("the value of PRIORITY_MAX", max_priority)

    # Under OS X, os.sysconf("SC_MQ_PRIO_MAX") returns -1.
    # This is still true in April 2025 under MacOS 15.3.
    if max_priority < 0:
        max_priority = DEFAULT_PRIORITY_MAX
.../build_support/discover_system_info.py...
{code}

If function compile_and_run return empty string "", such as cross compiling, stdout is empyt, strerr has output

$ ./build_support/src/foo
./build_support/src/foo: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.34' not found (required by ./build_support/src/foo) $ ./build_support/src/foo 2>/dev/null

In this situation, max_priority = "", and 'if max_priority' and 'if max_priority is None:' will false, then 'if max_priority < 0' will fail

|   File "path-to/posix_ipc-1.2.0/build_support/discover_system_info.py", line 238, in sniff_mq_prio_max
|     if max_priority < 0:
|        ^^^^^^^^^^^^^^^^
| TypeError: '<' not supported between instances of 'str' and 'int'

This commit make compile_and_run return non-empty string or None to avoid the issue