### PR TITLE
Fix system_info.h copy bug

### DIFF
--- a/.github/workflows/build-wheels.yaml
+++ b/.github/workflows/build-wheels.yaml
@@ -20,7 +20,7 @@ jobs:
       fail-fast: false
       matrix:
         # macos-13 is an intel runner, macos-14 is apple silicon
-        os: [ubuntu-latest, ubuntu-24.04-arm, macos-13, macos-14]
+        os: [ubuntu-latest, ubuntu-24.04-arm, macos-13, macos-14, macos-15]
 
     steps:
       - uses: actions/checkout@v4

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,9 +1,6 @@
 include INSTALL LICENSE VERSION
 include README.md USAGE.md history.md
 include src/posix_ipc_module.c
-# Don't include system_info.h. It's system specific, and should be re-created
-# for each build except under unusual circumstances.
-exclude src/system_info.h
 graft build_support
 graft tests
 # I use recursive-include instead of graft so that I don't accidentally


### PR DESCRIPTION
Ensure a custom `system_info.h` is copied when using `python -m build`. 

Bonus fix: add Mac OS 15 wheels.

Fixes #82