### PR TITLE
Refactor system info discovery

### DIFF
--- a/build_support/discover_system_info.py
+++ b/build_support/discover_system_info.py
@@ -24,45 +24,6 @@ class POSIXNonComplianceWarning(UserWarning):
     pass
 
 
-# This is the max length that I want a printed line to be.
-MAX_LINE_LENGTH = 78
-
-
-def line_wrap_paragraph(s):
-    # Format s with terminal-friendly line wraps.
-    done = False
-    beginning = 0
-    end = MAX_LINE_LENGTH - 1
-    lines = []
-    while not done:
-        if end >= len(s):
-            done = True
-            lines.append(s[beginning:])
-        else:
-            last_space = s[beginning:end].rfind(' ')
-
-            lines.append(s[beginning:beginning + last_space])
-            beginning += (last_space + 1)
-            end = beginning + MAX_LINE_LENGTH - 1
-
-    return lines
-
-
-def print_bad_news(value_name, default):
-    s = "Setup can't determine %s on your system, so it will default to %s which " \
-        "may not be correct." % (value_name, default)
-    plea = "Please report this message and your operating system info to the package " \
-           "maintainer listed in the README file."
-
-    lines = line_wrap_paragraph(s) + [''] + line_wrap_paragraph(plea)
-
-    border = '*' * MAX_LINE_LENGTH
-
-    s = border + "\n* " + ('\n* '.join(lines)) + '\n' + border
-
-    print(s)
-
-
 def does_build_succeed(filename, linker_options=""):
     # Utility function that returns True if the file compiles and links
     # successfully, False otherwise.
@@ -235,41 +196,36 @@ def sniff_mq_existence(linker_options):
 
 
 def sniff_mq_prio_max():
-    # MQ_PRIO_MAX is #defined in limits.h on all of the systems that I
-    # checked that support message queues at all. (I checked 2 Linux boxes,
-    # OpenSolaris and FreeBSD 8.0.)
+    '''Returns the value of MQ_PRIO_MAX, formatted for inclusion in system_info.h.
 
-    # 32 = minimum allowable max priority per POSIX; systems are permitted
-    # to define a larger value.
-    # ref: http://www.opengroup.org/onlinepubs/009695399/basedefs/limits.h.html
-    DEFAULT_PRIORITY_MAX = 32
+    Raises a DiscoveryError exception if unable to determine the value.
+    '''
+    # Max queue priority should be present in sysconf() on POSIX-compliant systems, and checking
+    # sysconf is easier than invoking the compiler.
+    max_priority = maybe_get_sysconf_value('SC_MQ_PRIO_MAX', True)
 
-    max_priority = None
-    # OS X up to and including 10.8 doesn't support POSIX messages queues and
-    # doesn't define MQ_PRIO_MAX. Maybe this aggravation will cease in 10.9?
-    if does_build_succeed("sniff_mq_prio_max.c"):
+    if not max_priority:
+        # OK, try to get it via compilation.
         max_priority = compile_and_run("sniff_mq_prio_max.c")
 
-    if max_priority:
-        try:
-            max_priority = int(max_priority)
-        except ValueError:
-            max_priority = None
+    # Regardless of where I got the value from, it should be int-able (if it's not an int already).
+    try:
+        max_priority = int(max_priority)
+    except Exception:
+        # I don't care why the conversion to int failed.
+        max_priority = None
+
+    # At this point, max_priority is an int, or None.
+
+    # Under OS X, os.sysconf("SC_MQ_PRIO_MAX") returns -1. This is still true in June 2025 under
+    # MacOS 15.5. sniff_mq_prio_max() shouldn't even be called when building on the Mac, but
+    # I'll leave this code here because maybe Mac isn't the only platform that behaves that way.
+    if max_priority and (max_priority < 0):
+        max_priority = None
 
     if max_priority is None:
-        # Looking for a #define didn't work; ask sysconf() instead.
-        # Note that sys.sysconf_names doesn't exist under Cygwin.
-        if hasattr(os, "sysconf_names") and \
-           ("SC_MQ_PRIO_MAX" in os.sysconf_names):
-            max_priority = os.sysconf("SC_MQ_PRIO_MAX")
-        else:
-            max_priority = DEFAULT_PRIORITY_MAX
-            print_bad_news("the value of PRIORITY_MAX", max_priority)
-
-    # Under OS X, os.sysconf("SC_MQ_PRIO_MAX") returns -1.
-    # This is still true in April 2025 under MacOS 15.3.
-    if max_priority < 0:
-        max_priority = DEFAULT_PRIORITY_MAX
+        # At this point, I've exhausted all of my options.
+        raise DiscoveryError('Unable to determine max message queue priority')
 
     # Adjust for the fact that these are 0-based values; i.e. permitted
     # priorities range from 0 - (MQ_PRIO_MAX - 1). So why not just make

--- a/build_support/discover_system_info.py
+++ b/build_support/discover_system_info.py
@@ -10,6 +10,10 @@ STDERR = subprocess.PIPE
 # STDOUT = None
 # STDERR = None
 
+class DiscoveryError(Exception):
+    '''Exception raised when this script is unable to discover a value that it needs.'''
+    pass
+
 # This is the max length that I want a printed line to be.
 MAX_LINE_LENGTH = 78
 
@@ -130,11 +134,7 @@ def sniff_realtime_lib():
             rc = True
 
     if rc is None:
-        # Unable to determine whether or not I needed the realtime libs.
-        # That's bad! Print a warning, set the return code to False
-        # and hope for the best.
-        rc = False
-        print_bad_news("if it needs to link to the realtime libraries", "'no'")
+        raise DiscoveryError('Unable to determine whether realtime lib is needed to build')
 
     return rc
 
@@ -191,8 +191,7 @@ def sniff_page_size():
         page_size = compile_and_run("sniff_page_size.c")
 
     if not page_size:
-        page_size = DEFAULT_PAGE_SIZE
-        print_bad_news("the value of PAGE_SIZE", page_size)
+        raise DiscoveryError('Unable to determine page size')
 
     return page_size
 

--- a/build_support/discover_system_info.py
+++ b/build_support/discover_system_info.py
@@ -1,7 +1,6 @@
 import subprocess
 import platform
 import os
-import sys
 
 # Set these to None for compile/link debugging or subprocess.PIPE to silence
 # compiler warnings and errors.
@@ -157,6 +156,7 @@ def sniff_sem_getvalue(linker_options):
 
 
 def sniff_sem_timedwait(linker_options):
+    '''Returns True if sem_timedwait() works on this system, False otherwise.'''
     return does_build_succeed("sniff_sem_timedwait.c", linker_options)
 
 
@@ -202,6 +202,7 @@ def sniff_page_size():
 
 
 def sniff_mq_existence(linker_options):
+    '''Returns True if the system supports message queues, False otherwise.'''
     return does_build_succeed("sniff_mq_existence.c", linker_options)
 
 

--- a/build_support/discover_system_info.py
+++ b/build_support/discover_system_info.py
@@ -25,19 +25,30 @@ class POSIXNonComplianceWarning(UserWarning):
 
 
 def does_build_succeed(filename, linker_options=""):
-    # Utility function that returns True if the file compiles and links
-    # successfully, False otherwise.
-    # Two things to note here --
+    '''Returns True if the file compiles and links successfully, False otherwise.
+
+    It can be perfectly normal for the build to fail, e.g. when building sniff_sem_getvalue.c on
+    a system where sem_getvalue() doesn't exist.
+
+    Note that unlike compile_and_run(), this just builds an executable. It does not attempt to
+    run that executable.
+    '''
+    # There are two things to note about the command --
     #   - If there's a linker option like -lrt, it needs to come *after*
     #     the specification of the C file or linking will fail on Ubuntu 11.10
     #     (maybe because of the gcc version?)
     #   - Some versions of Linux place the sem_xxx() functions in libpthread.
     #     Rather than testing whether or not it's needed, I just specify it
     #     everywhere since it's harmless to specify it when it's not needed.
-    cc = os.getenv("CC", "cc")
-    cmd = "%s -Wall -o ./build_support/src/foo ./build_support/src/%s %s -lpthread" % (cc, filename, linker_options)
-
-    p = subprocess.Popen(cmd, shell=True, stdout=STDOUT, stderr=STDERR)
+    cmd = [os.getenv("CC", "cc"),
+           '-Wall',
+           '-o',
+           f'./build_support/src/{filename[:-2]}',
+           f'./build_support/src/{filename}',
+           linker_options,
+           '-lpthread'
+           ]
+    p = subprocess.Popen(cmd, stdout=STDOUT, stderr=STDERR)
 
     # p.wait() returns the process' return code, so 0 implies that
     # the compile & link succeeded.
@@ -45,24 +56,23 @@ def does_build_succeed(filename, linker_options=""):
 
 
 def compile_and_run(filename, linker_options=""):
-    # Utility function that returns the stdout output from running the
-    # compiled source file; None if the compile fails.
-    cc = os.getenv("CC", "cc")
-    cmd = "%s -Wall -o ./build_support/src/foo %s ./build_support/src/%s" % (cc, linker_options, filename)
+    '''Compiles and links the file, runs the executable, and returns whatever the executable
+    prints to stdout.
 
-    p = subprocess.Popen(cmd, shell=True, stdout=STDOUT, stderr=STDERR)
-
-    if p.wait():
-        # uh-oh, compile failed
-        return None
-    
-    try:
-        s = subprocess.Popen(["./build_support/src/foo"],
-                             stdout=subprocess.PIPE).communicate()[0]
-        return s.strip().decode()
-    except Exception:
-        # execution resulted in an error
-        return None
+    Failure of any of the steps (compile, link, run) is unexepected. This function returns None
+    in that case.
+    '''
+    if does_build_succeed(filename, linker_options):
+        cmd = f"./build_support/src/{filename[:-2]}"
+        try:
+            s = subprocess.Popen([cmd], stdout=subprocess.PIPE).communicate()[0]
+            return s.strip().decode()
+        except Exception:
+            # Execution resulted in an error. This is unexpected.
+            return None
+    else:
+        # Build resulted in an error. This is unexpected.
+         return None
 
 
 def get_sysctl_value(name):
@@ -369,7 +379,7 @@ def discover():
 
     if realtime_lib_is_needed:
         d["REALTIME_LIB_IS_NEEDED"] = ""
-        linker_options = " -lrt "
+        linker_options = "-lrt"
 
     d["PAGE_SIZE"] = sniff_page_size()
 

--- a/build_support/discover_system_info.py
+++ b/build_support/discover_system_info.py
@@ -10,9 +10,19 @@ STDERR = subprocess.PIPE
 # STDOUT = None
 # STDERR = None
 
+
 class DiscoveryError(Exception):
     '''Exception raised when this script is unable to discover a value that it needs.'''
     pass
+
+
+class POSIXNonComplianceWarning(UserWarning):
+    '''Warning emitted when the underlying OS appears not to be POSIX compliant. POSIX compliance
+    ensures (among other things) that important system information is available via sysconf().
+    See https://github.com/osvenskan/posix_ipc/issues/81 for details.
+    '''
+    pass
+
 
 # This is the max length that I want a printed line to be.
 MAX_LINE_LENGTH = 78
@@ -117,6 +127,30 @@ def get_sysctl_value(name):
         pass
 
     return s
+
+
+def maybe_get_sysconf_value(name, complain_if_not_present=False):
+    """Returns the value of a sysconf entry (e.g. 'SC_PAGESIZE') if the entry exists. If the value
+    isn't available via sysconf, this function returns None.
+
+    When complain_if_not_present is True, that means the sysconf value must be present for the
+    system to be POSIX compliant. If the value is required but not present, this function raises
+    a POSIXNonComplianceWarning to alert the user.
+
+    Reference: https://pubs.opengroup.org/onlinepubs/9799919799.2024edition/functions/sysconf.html
+    """
+    value = None
+
+    # Years ago, Cygwin didn't support os.sysconf_names. That has probably changed, but I don't
+    # want to assume.
+    if hasattr(os, 'sysconf_names'):
+        if name in os.sysconf_names:
+            value = os.sysconf(name)
+
+    if complain_if_not_present and (value is None):
+        raise POSIXNonComplianceWarning(f'Value "{name}" is missing from sysconf')
+
+    return value
 
 
 def sniff_realtime_lib():

--- a/build_support/discover_system_info.py
+++ b/build_support/discover_system_info.py
@@ -161,21 +161,14 @@ def sniff_sem_timedwait(linker_options):
 
 
 def sniff_sem_value_max():
-    # default is to return None which means that it is #defined in a standard
-    # header file and doesn't need to be added to my custom header file.
-    sem_value_max = None
+    '''Returns either None, or a value suitable for inclusion in system_info.h.'''
+    # The max semaphore value should be present in sysconf() on POSIX-compliant systems.
+    sem_value_max = maybe_get_sysconf_value('SC_SEM_VALUE_MAX', True)
 
-    if not does_build_succeed("sniff_sem_value_max.c"):
-        # OpenSolaris 2008.05 doesn't #define SEM_VALUE_MAX. (This may
-        # be true elsewhere too.) Ask sysconf() instead if it exists.
-        # Note that sys.sysconf_names doesn't exist under Cygwin.
-        if hasattr(os, "sysconf_names") and \
-           ("SC_SEM_VALUE_MAX" in os.sysconf_names):
-            sem_value_max = os.sysconf("SC_SEM_VALUE_MAX")
-        else:
-            # This value of last resort should be #defined everywhere. What
-            # could possibly go wrong?
-            sem_value_max = "_POSIX_SEM_VALUE_MAX"
+    if not sem_value_max:
+        # This value of last resort should be #defined everywhere. What
+        # could possibly go wrong?
+        sem_value_max = "_POSIX_SEM_VALUE_MAX"
 
     return sem_value_max
 

--- a/build_support/discover_system_info.py
+++ b/build_support/discover_system_info.py
@@ -11,6 +11,10 @@ STDERR = subprocess.PIPE
 # STDERR = None
 
 
+# A few behaviors depend on whether or not this runs on a Mac.
+IS_MAC = ("Darwin" in platform.uname())
+
+
 class DiscoveryError(Exception):
     '''Exception raised when this script is unable to discover a value that it needs.'''
     pass
@@ -142,7 +146,14 @@ def sniff_realtime_lib():
 
 
 def sniff_sem_getvalue(linker_options):
-    return does_build_succeed("sniff_sem_getvalue.c", linker_options)
+    '''Returns True if sem_getvalue() works on this system, False otherwise.'''
+    if IS_MAC:
+        # On the Mac, sem_getvalue() exists but always returns -1 (under OS X ≥ 10.9) or
+        # ENOSYS ("Function not implemented") under some earlier version(s). It's a waste of
+        # time to look for it on that platform.
+        return False
+    else:
+        return does_build_succeed("sniff_sem_getvalue.c", linker_options)
 
 
 def sniff_sem_timedwait(linker_options):
@@ -382,12 +393,6 @@ def discover():
 
     if sniff_sem_getvalue(linker_options):
         d["SEM_GETVALUE_EXISTS"] = ""
-
-    if ("SEM_GETVALUE_EXISTS" in d) and ("Darwin" in platform.uname()):
-        # sem_getvalue() isn't available on OS X. The function exists but
-        # always returns -1 (under OS X 10.9) or ENOSYS ("Function not
-        # implemented") under some earlier version(s).
-        del d["SEM_GETVALUE_EXISTS"]
 
     if sniff_sem_timedwait(linker_options):
         d["SEM_TIMEDWAIT_EXISTS"] = ""

--- a/build_support/discover_system_info.py
+++ b/build_support/discover_system_info.py
@@ -10,6 +10,12 @@ STDERR = subprocess.PIPE
 # STDERR = None
 
 
+# OUTPUT_FILEPATH is the file that this script will write, if necessary. The path is relative
+# to the project root. Setuptools guarantees that the project root will be the current working
+# directory when this script executes.
+OUTPUT_FILEPATH = "./src/system_info.h"
+
+
 # A few behaviors depend on whether or not this runs on a Mac.
 IS_MAC = ("Darwin" in platform.uname())
 
@@ -358,82 +364,95 @@ def sniff_mq_max_message_size_default():
 
 
 def discover():
-    linker_options = ""
-    d = {}
+    '''This is the main entry point for this script. It returns a dict of information it has
+    discovered about the buld system. If system_info.h already exists when this script is
+    invoked, then the returned dict consists only of one entry which describes whether or not
+    posix_ipc needs to be linked to the realtime library.
 
-    f = open("VERSION")
-    d["POSIX_IPC_VERSION"] = '"%s"' % f.read().strip()
-    f.close()
+    If system_info.h does not exist, this script creates and populates it, and the values in the
+    returned dict are what it wrote to system_info.h.
+    '''
+    sys_info = {}
 
-    # Sniffing of the realtime libs has to go early in the list so as
-    # to provide correct linker options to the rest of the tests.
-    if "Darwin" in platform.uname():
-        # I skip the test under Darwin/OS X for two reasons. First, I know
-        # it isn't needed there. Second, I can't even compile the test for
-        # the realtime lib because it references mq_unlink() which OS X
-        # doesn't support. Unfortunately sniff_realtime_lib.c *must*
-        # reference mq_unlink() or some other mq_xxx() function because
-        # it is only the message queues that need the realtime libs under
-        # FreeBSD.
+    # First things first -- I need to figure out whether or not the realtime library is needed.
+    if IS_MAC:
+        # I skip the test under Darwin/Mac/OS X for two reasons. First, I know it isn't needed
+        # there. Second, I can't even compile the test for the realtime lib because it
+        # references mq_unlink() which OS X doesn't support. Unfortunately sniff_realtime_lib.c
+        # *must* reference mq_unlink() or some other mq_xxx() function, because only the message
+        # queues need the realtime libs under FreeBSD.
         realtime_lib_is_needed = False
     else:
-        # Some platforms (e.g. Linux & OpenSuse) require linking to librt
+        # Some platforms (e.g. Linux) require linking to librt
         realtime_lib_is_needed = sniff_realtime_lib()
 
-    if realtime_lib_is_needed:
-        d["REALTIME_LIB_IS_NEEDED"] = ""
-        linker_options = "-lrt"
+    sys_info['realtime_lib_is_needed'] = realtime_lib_is_needed
 
-    d["PAGE_SIZE"] = sniff_page_size()
+    linker_options = "-lrt" if realtime_lib_is_needed else ""
 
-    if sniff_sem_getvalue(linker_options):
-        d["SEM_GETVALUE_EXISTS"] = ""
+    if os.path.exists(OUTPUT_FILEPATH):
+        # As guaranteed in building.md, this script is (mostly) a no-op if the output file already
+        # exists.
+        pass
+    else:
+        # system_info.h doesn't exist, so I need to figure out what values should go into it.
 
-    if sniff_sem_timedwait(linker_options):
-        d["SEM_TIMEDWAIT_EXISTS"] = ""
+        # Version info is easy. :-)
+        with open("VERSION") as f:
+            sys_info["POSIX_IPC_VERSION"] = f'"{f.read().strip()}"'
 
-    d["SEM_VALUE_MAX"] = sniff_sem_value_max()
-    # A return of None means that I don't need to #define this myself.
-    if d["SEM_VALUE_MAX"] is None:
-        del d["SEM_VALUE_MAX"]
+        # Figure out the page size.
+        sys_info["PAGE_SIZE"] = sniff_page_size()
 
-    if sniff_mq_existence(linker_options):
-        d["MESSAGE_QUEUE_SUPPORT_EXISTS"] = ""
+        # Sniff sem_getvalue()
+        if sniff_sem_getvalue(linker_options):
+            sys_info["SEM_GETVALUE_EXISTS"] = ""
 
-    d["QUEUE_MESSAGES_MAX_DEFAULT"] = sniff_mq_max_messages()
-    d["QUEUE_MESSAGE_SIZE_MAX_DEFAULT"] = sniff_mq_max_message_size_default()
-    d["QUEUE_PRIORITY_MAX"] = sniff_mq_prio_max()
+        # Sniff sem_timedwait()
+        if sniff_sem_timedwait(linker_options):
+            sys_info["SEM_TIMEDWAIT_EXISTS"] = ""
 
-    msg = """/*
-This header file was generated when you ran setup. Once created, the setup
-process won't overwrite it, so you can adjust the values by hand and
-recompile if you need to.
+        # Sniff the max value of a semaphore.
+        sys_info["SEM_VALUE_MAX"] = sniff_sem_value_max()
 
-On your platform, this file may contain only this comment -- that's OK!
+        # Figure out if message queues are supported at all.
+        message_queue_support_exists = sniff_mq_existence(linker_options)
 
-To enable lots of debug output, add this line and re-run setup.py:
-#define POSIX_IPC_DEBUG
+        if message_queue_support_exists:
+            sys_info["MESSAGE_QUEUE_SUPPORT_EXISTS"] = ""
+            sys_info["QUEUE_MESSAGES_MAX_DEFAULT"] = sniff_mq_max_messages_default()
+            sys_info["QUEUE_MESSAGE_SIZE_MAX_DEFAULT"] = sniff_mq_max_message_size_default()
+            sys_info["QUEUE_PRIORITY_MAX"] = sniff_mq_prio_max()
 
-To recreate this file, just delete it and re-run setup.py.
-*/
-
-"""
-    filename = "./src/system_info.h"
-    if not os.path.exists(filename):
-        lines = ["#define %s\t\t%s" % (key, d[key]) for key in d if key != "PAGE_SIZE"]
+        # Turn each of the values in sys_info into lines that will be written to system_info.h
+        # PAGE_SIZE and SEM_VALUE_MAX get special handling, and realtime_lib_is_needed doesn't
+        # need to go in the header file.
+        ignore = ("PAGE_SIZE", "SEM_VALUE_MAX", "realtime_lib_is_needed")
+        lines = [f"#define {key} {value}" for key, value in sys_info.items() if key not in ignore]
 
         # PAGE_SIZE gets some special treatment. It's defined in header files
         # on some systems in which case I might get a redefinition error in
         # my header file, so I wrap it in #ifndef/#endif.
-
         lines.append("#ifndef PAGE_SIZE")
-        lines.append("#define PAGE_SIZE\t\t%s" % d["PAGE_SIZE"])
+        lines.append(f"#define PAGE_SIZE {sys_info['PAGE_SIZE']}")
         lines.append("#endif")
+        # Ditto for SEM_VALUE_MAX.
+        lines.append("#ifndef SEM_VALUE_MAX")
+        lines.append(f"#define SEM_VALUE_MAX {sys_info['SEM_VALUE_MAX']}")
+        lines.append("#endif")
+        # A trailing blank line keeps compilers happy.
+        lines.append('')
 
-        # A trailing '\n' keeps compilers happy...
-        open(filename, "w").write(msg + '\n'.join(lines) + '\n')
+        msg = """/*
+This header file was generated by discover_system_info.py. You can delete it,
+edit it, or even write your own. See building.md for details.
+*/
 
-    return d
+"""
+        with open(OUTPUT_FILEPATH, 'w') as f:
+            f.write(msg + '\n'.join(lines))
+
+    return sys_info
 
 
 if __name__ == "__main__":

--- a/build_support/discover_system_info.py
+++ b/build_support/discover_system_info.py
@@ -76,11 +76,8 @@ def compile_and_run(filename, linker_options=""):
 
 
 def get_sysctl_value(name):
-    """Given a sysctl name (e.g. 'kern.mqueue.maxmsg'), returns sysctl's value
-    for that variable or None if the sysctl call fails (unknown name, not
-    a BSD-ish system, etc.)
-
-    Only makes sense on systems that implement sysctl (BSD derivatives).
+    """Given a sysctl name (e.g. 'kern.mqueue.maxmsg'), returns sysctl's value for that variable
+    or None if the sysctl call fails (unknown name, sysctl not supported, etc.)
     """
     s = None
     try:
@@ -94,7 +91,7 @@ def get_sysctl_value(name):
                              stdout=subprocess.PIPE,
                              stderr=open(os.devnull, 'rw')).communicate()[0]
         s = s.strip().decode()
-    except:
+    except Exception:
         pass
 
     return s

--- a/build_support/discover_system_info.py
+++ b/build_support/discover_system_info.py
@@ -246,7 +246,16 @@ def sniff_mq_prio_max():
     return str(max_priority).strip() + "U"
 
 
-def sniff_mq_max_messages():
+def sniff_mq_max_messages_default():
+    '''Returns the value (in bytes) that will be used for the module constant
+    QUEUE_MESSAGES_MAX_DEFAULT. This value is only used when creating a MessageQueue; it is the
+    default value if the caller doesn't supply one.
+
+    The value returned by this function is formatted for inclusion in system_info.h.
+
+    Since this value is of minor consequence, I return a default value (instead of raising an error)
+    if this function can't find a system-supplied value.
+    '''
     # This value is not defined by POSIX.
 
     # On most systems I've tested, msg Qs are implemented via mmap-ed files
@@ -272,9 +281,9 @@ def sniff_mq_max_messages():
     mq_max_messages = None
 
     # Try to get the value from where Linux stores it.
-    try:
-        mq_max_messages = int(open("/proc/sys/fs/mqueue/msg_max").read())
-    except:
+    with open("/proc/sys/fs/mqueue/msg_max") as f:
+        mq_max_messages = int(f.read())
+    except Exception:
         # Oh well.
         pass
 
@@ -285,26 +294,9 @@ def sniff_mq_max_messages():
             mq_max_messages = int(mq_max_messages)
 
     if not mq_max_messages:
-        # We're on a non-Linux, non-BSD system, or OS X, or BSD with
-        # the mqueuefs kernel module not loaded (which it's not, by default,
-        # under FreeBSD 8.x and 9.x which are the only systems I've tested).
-        #
-        # If we're on FreeBSD and mqueuefs isn't loaded when this code runs,
-        # sysctl won't be able to provide mq_max_messages to me. (I assume other
-        # BSDs behave the same.) If I use too large of a default, then every
-        # attempt to create a message queue via posix_ipc will fail with
-        # "ValueError: Invalid parameter(s)"  unless the user explicitly sets
-        # the max_messages param.
-        if platform.system().endswith("BSD"):
-            # 100 is the value I see under FreeBSD 9.2. I hope this works
-            # elsewhere!
-            mq_max_messages = 100
-        else:
-            # We're on a non-Linux, non-BSD system. I take a wild guess at an
-            # appropriate value. The max possible is > 2 billion, but the
-            # values used by Linux and FreeBSD suggest that a smaller default
-            # is wiser.
-            mq_max_messages = 1024
+        # I take a wild guess at an appropriate value. The max possible is > 2 billion, but the
+        # values used by Linux and FreeBSD suggest that a smaller default is wiser.
+        mq_max_messages = 100
 
     return mq_max_messages
 

--- a/build_support/discover_system_info.py
+++ b/build_support/discover_system_info.py
@@ -174,11 +174,10 @@ def sniff_sem_value_max():
 
 
 def sniff_page_size():
-    # 4096 is a common page size on x86. As the world moves increasingly to ARM architectures,
-    # this might not be a good default anymore, but the default value isn't really supposed to
-    # be used except when all else fails (and in that case the user gets a warning).
-    DEFAULT_PAGE_SIZE = 4096
+    '''Returns the page size (usually 4096 or 16384) suitable for inclusion in system_info.h.
 
+    Raises a DiscoveryError exception if unable to determine the page size.
+    '''
     page_size = None
 
     # When cross compiling under cibuildwheel, I need to rely on their custom env var to set the
@@ -187,9 +186,9 @@ def sniff_page_size():
         page_size = 16384
 
     if not page_size:
-        # Maybe I can find page size in os.sysconf(). If so, that saves a compilation step.
-        if 'SC_PAGESIZE' in os.sysconf_names:
-            page_size = os.sysconf('SC_PAGESIZE')
+        # Page size should be present in sysconf() on POSIX-compliant systems, and checking
+        # sysconf is easier than invoking the compiler.
+        page_size = maybe_get_sysconf_value('SC_PAGESIZE', True)
 
     if not page_size:
         # OK, I have to do it the hard way. I don't need to worry about linker options here

--- a/build_support/discover_system_info.py
+++ b/build_support/discover_system_info.py
@@ -288,14 +288,15 @@ def sniff_mq_max_messages_default():
     mq_max_messages = None
 
     # Try to get the value from where Linux stores it.
-    with open("/proc/sys/fs/mqueue/msg_max") as f:
-        mq_max_messages = int(f.read())
+    try:
+        with open("/proc/sys/fs/mqueue/msg_max") as f:
+            mq_max_messages = int(f.read())
     except Exception:
         # Oh well.
         pass
 
     if not mq_max_messages:
-        # Maybe we're on BSD.
+        # Try sysctl
         mq_max_messages = get_sysctl_value('kern.mqueue.maxmsg')
         if mq_max_messages:
             mq_max_messages = int(mq_max_messages)

--- a/build_support/discover_system_info.py
+++ b/build_support/discover_system_info.py
@@ -302,6 +302,15 @@ def sniff_mq_max_messages_default():
 
 
 def sniff_mq_max_message_size_default():
+    '''Returns the value (in bytes) that will be used for the module constant
+    QUEUE_MESSAGE_SIZE_MAX_DEFAULT. This value is only used when creating a MessageQueue; it is the
+    default value if the caller doesn't supply one.
+
+    The value returned by this function is formatted for inclusion in system_info.h.
+
+    Since this value is of minor consequence, I return a default value (instead of raising an error)
+    if this function can't find a system-supplied value.
+    '''
     # The max message size is not defined by POSIX.
 
     # On most systems I've tested, msg Qs are implemented via mmap-ed files
@@ -328,19 +337,20 @@ def sniff_mq_max_message_size_default():
 
     # Try to get the value from where Linux stores it.
     try:
-        mq_max_message_size_default = \
-                            int(open("/proc/sys/fs/mqueue/msgsize_max").read())
-    except:
+        with open("/proc/sys/fs/mqueue/msgsize_max") as f:
+            mq_max_message_size_default = int(f.read())
+    except Exception:
         # oh well
         pass
 
     if not mq_max_message_size_default:
-        # Maybe we're on BSD.
+        # Try sysctl
         mq_max_message_size_default = get_sysctl_value('kern.mqueue.maxmsgsize')
         if mq_max_message_size_default:
             mq_max_message_size_default = int(mq_max_message_size_default)
 
     if not mq_max_message_size_default:
+        # Just use the default.
         mq_max_message_size_default = DEFAULT
 
     return mq_max_message_size_default

--- a/setup.py
+++ b/setup.py
@@ -22,9 +22,12 @@ libraries = []
 
 system_info = build_support.discover_system_info.discover()
 
-# Linux & FreeBSD require linking against the realtime libs.
-# This causes an error on other platforms
-if "realtime_lib_is_needed" in system_info:
+# Linux requires linking against the realtime libs. My notes say that FreeBSD also required this,
+# but it looks like librt on FreeBSD is a raytracing library so maybe not. :-) In any case,
+# adding "rt" to the list of linked libraries on platforms where it doesn't exist (e.g. Mac)
+# causes a build failure (due to a link error), so I need to be careful about only adding it
+# where it's needed.
+if system_info['realtime_lib_is_needed']:
     libraries.append("rt")
 
 ext_modules = [Extension("posix_ipc",

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ system_info = build_support.discover_system_info.discover()
 
 # Linux & FreeBSD require linking against the realtime libs.
 # This causes an error on other platforms
-if "REALTIME_LIB_IS_NEEDED" in system_info:
+if "realtime_lib_is_needed" in system_info:
     libraries.append("rt")
 
 ext_modules = [Extension("posix_ipc",


### PR DESCRIPTION
Refactor `discover_system_info.py`. This is the first significant update to this code since it was written 17 years ago (as `prober.py`) so the update was long overdue and probably introduced a few new bugs. 😬

See #62 for some context. 

I tried to be extra careful to make this reviewable commit by commit because there are a lot of changes.

## Functional Changes

 - When `system_info.h` exists, this script does as little as possible. Currently, that means only checking to see if the realtime lib is needed for linking
 - Raises `DiscoveryError` when it can't figure out a critical value
 - Emits `POSIXNonComplianceWarning` as appropriate
 - Avoids compile & run steps wherever possible by first consulting sysconf
 - On platforms where Message Queues are not supported (e.g. Mac), don't bother trying to detect any of the Message Queue-related values (like `MQ_PRIO_MAX`, etc.)
 - Instead of conditionally including `SEM_VALUE_MAX` in the output file, now it's always included but surrounded with `#ifndef/#endif`.

## Non-functional Changes

 - Added docstrings where they were missing
 - Removed stale platform-specific info  
 - General cleanup and code tidying including some changes suggested in #77


Fixes #62