### PR TITLE
Document system info header file

### DIFF
--- a/building.md
+++ b/building.md
@@ -1,49 +1,27 @@
 # Building/Compiling POSIX IPC
 
-You can build `posix_ipc` with a normal build command like `python -m build`. This document describes an unusual step that happen at build time.
+You can build `posix_ipc` with a normal build command like `python -m build`. If this works for you, you don't need to read any further. But if you're curious, or the build is not working for you, you might want to read this document about an unusual step that happen at build time to create a special C header file.
 
 ## System Information Discovery
 
-`posix_ipc` needs to know various IPC-related facts about its host system. For instance, some operating systems don't offer a timed wait function for semaphores. This module wants to make that functionality available when it's present, and also needs to know when it's not present and therefore can't be called.
+`posix_ipc` needs to know various IPC-related facts about its host system. For instance, some operating systems don't offer a timed wait function for semaphores. This module wants to make that functionality available when it's present, and also needs to know when it's _not_ present and therefore can't be used.
 
-This kind of information needs to be known before `posix_ipc` is compiled. To get that information, `build_support/discover_system_info.py` runs when `setup.py` is invoked. Here's some information about that script.
+This kind of information needs to be known before `posix_ipc` is compiled. To get that information, `build_support/discover_system_info.py` runs when `setup.py` is invoked. (In `posix_ipc` releases prior to 1.2, this script was called `prober.py`.)
 
-## The Script
+The goal of `discover_system_info.py` is to write a C header file called `src/system_info.h`. (In `posix_ipc` releases prior to 1.2, this file was called `probe_results.h`.) This header file isn't part of the source distribution, nor should it be. It contains values that are specific to the system on which `posix_ipc` is built.
 
-The best documentation for the script is currently the script itself. I hope to provide more formal documentation in a future release. Please don't laugh at the code too much. It's been adjusted over the years, but the core of it was written in 2008 when both Python and I had different standards. In `posix_ipc` releases prior to 1.2, this script was called `prober.py`.
+## The System Info Header File
 
-The script writes a C header file which is described below.
+A sample header file (`system_info.sample.h`) is included in this distribution. It contains all of the possible entries that _could_ be present in the file, along with documentation about each.
 
-## The Header File
+In addition to allowing the build process to create this file for you, you can also write your own `src/system_info.h`. **If that file exists when `posix_ipc` is built, the build system will use your version instead of creating its own.** This can be useful if `discover_system_info.py` is failing for some reason, or if you think it's generating the wrong values. It can also help support cross compilation scenarios. (See below.)
 
-The goal of `discover_system_info.py` is to write `src/system_info.h`. (In `posix_ipc` releases prior to 1.2, this file was called `probe_results.h`.) This header file isn't part of the source distribution, nor should it be. It contains values that are specific to the system on which `posix_ipc` is built.
+If you want to create your own `system_info.h`, copy `system_info.sample.h` to `src/system_info.h`, and edit `src/system_info.h` before you build.
 
-If the file exists when `discover_system_info.py` runs, it will not be overwritten. This allows developers to create their own `system_info.h` (to enable debugging messages from `posix_ipc`, for instance.)
+### Cross Compilation
 
-It's critical to understand that the values in the header file _describe_ your system to `posix_ipc`. They don't change the behavior of your operating system. For instance, if you decide to change `SEM_VALUE_MAX` in `system_info.h` to a larger number, that won't actually increase the maximum valid value for a semaphore on your system. It will only misinform `posix_ipc` about what your system accepts, and a misinformed `posix_ipc` will probably behave badly.
+If you want to run `posix_ipc` on a system other than the one where it was built, you'll probably be better off if you create a custom `system_info.h`. In fact, it might be your only option. A couple of scenarios in `discover_system_info.py` need to run small C programs that are compiled on the fly. If your build system can't run the binaries it creates for your target system, `discover_system_info.py` might raise a `DiscoveryError` exception.
 
-### Header File Values
+### Descriptive, Not Definitive
 
-These are the `#define` values that can appear in the header file. The format of this file might change in a future release; see https://github.com/osvenskan/posix_ipc/issues/62
-
- - `POSIX_IPC_VERSION` - A string, e.g. "1.1.1"
-
- - `POSIX_IPC_DEBUG` - A boolean. If present, `posix_ipc` will print messages to `stderr` as it runs. (Use this with care; it's a developer-only feature and the implementation isn't very robust.)
-
- - `REALTIME_LIB_IS_NEEDED` - A boolean. If present, then the setup procedure will link to `librt` at build time. If absent, the setup procedure will not link to `librt`.
-
- - `PAGE_SIZE` - An integer, e.g. 8192
-
- - `SEM_GETVALUE_EXISTS` - A boolean. If present, then the OS supports `sem_getvalue()`, so `posix_ipc` can implement `Semaphore.value`. If not present, `sem_getvalue()` isn't supported, so `Semaphore.value` will raise an `AttributeError`.
-
- - `SEM_TIMEDWAIT_EXISTS` - A boolean. If present, then the OS supports `sem_timedwait()`, so `posix_ipc` can enable `Semaphore.acquire()` with timeouts other than 0 and infinite. If not present, `sem_timedwait()` isn't supported. (See [the documentation for `Semaphore.acquire()`](usage.md#semaphore-acquire-method.)
-
- - `SEM_VALUE_MAX` - An integer that describes the maximum value of a semaphore, e.g. 32767
-
- - `MESSAGE_QUEUE_SUPPORT_EXISTS` - A boolean. If present, then the host system implements POSIX message queues. If not present, `posix_ipc` can't offer any `MessageQueue` features. (Mac OS is an example of a platform that doesn't implement POSIX message queues.)
-
- - `QUEUE_MESSAGES_MAX_DEFAULT` - A integer, e.g. 10. When creating a message queue, this value is supplied for the queue's `max_messages` parameter if one isn't specified by the caller.
-
- - `QUEUE_MESSAGE_SIZE_MAX_DEFAULT` - A integer, e.g. 8192. When creating a message queue, this value is supplied for the queue's `max_message_size` parameter if one isn't specified by the caller.
-
- - `QUEUE_PRIORITY_MAX` - A integer, e.g. 32, that describes the largest priority value that a message can have.
+It's very important to understand that the values in `system_info.h` _describe_ your system to `posix_ipc`. They don't change the behavior of your operating system. For instance, if you arbitrarily change `SEM_VALUE_MAX` in `system_info.h` to a larger number, that won't actually increase the maximum valid value for a semaphore on your system. It will only misinform `posix_ipc` about what your system accepts, and a misinformed `posix_ipc` will probably behave badly.

--- a/system_info.sample.h
+++ b/system_info.sample.h
@@ -1,0 +1,97 @@
+/*
+This is a sample version of system_info.h. See building.md for more information
+about why you might find it interesting.
+
+In addition to the values documented below, you can also add this one --
+
+#define POSIX_IPC_DEBUG
+
+Doing so will cause posix_ipc to print messages to stderr as it runs. Use this
+with care; it's a developer-only feature and the implementation isn't very
+robust.
+*/
+
+/* POSIX_IPC_VERSION should be a quoted string. It's what the module will
+report in its VERSION and __version__ attributes.
+*/
+#define POSIX_IPC_VERSION "1.2.0"
+
+/* PAGE_SIZE is the size (in bytes) of a block of memory. When allocating
+shared memory, some systems will round odd sizes up to the next PAGE_SIZE
+unit. (e.g. if PAGE_SIZE is 16384, a block that is nominally 10k would still
+occupy 16k of shared memory.)
+
+You should be able to get this value via Python using this command --
+
+    python -c "import os; print(os.sysconf('SC_PAGE_SIZE'))"
+
+This value only provides information to module users. The module reports it as
+posix_ipc.PAGE_SIZE, but that value isn't used anywhere in the module code,
+so if it's wrong, that might not matter to you.
+
+PAGE_SIZE is already #defined in system header files on many systems, so
+it should be surrounded with #ifndef/#endif here.
+*/
+#ifndef PAGE_SIZE
+#define PAGE_SIZE                       16384
+#endif
+
+/* MESSAGE_QUEUE_SUPPORT_EXISTS should be #defined if and only if the host OS
+supports message queues. (They're not supported on Mac.) If this is not
+#defined in this file, message queue support will not be available in
+the compiled module.
+*/
+#define MESSAGE_QUEUE_SUPPORT_EXISTS
+
+/* QUEUE_MESSAGES_MAX_DEFAULT is the default value for the max number of
+messages in a MessageQueue. It's only used if the caller doesn't supply a
+value when creating an instance.
+*/
+#define QUEUE_MESSAGES_MAX_DEFAULT      10
+
+/* QUEUE_MESSAGE_SIZE_MAX_DEFAULT is the default value for the max size
+(in bytes) of messages in a MessageQueue. It's only used if the caller doesn't
+supply a value when creating an instance.
+*/
+#define QUEUE_MESSAGE_SIZE_MAX_DEFAULT  8192
+
+/* QUEUE_PRIORITY_MAX defines the (0-based) upper bound of message
+priorities. 31 is the minimum allowable value for POSIX compliance. Some
+systems allow much higher values (e.g. 32768).
+
+You should be able to get this value via Python using this command --
+
+    python -c "import os; print(os.sysconf('SC_MQ_PRIO_MAX'))"
+
+This is an unsigned int, so in this file it must be followed by the letter U.
+
+This value is enforced by posix_ipc. If you try to send a message with a
+priority > QUEUE_PRIORITY_MAX, posix_ipc will raise an exception.
+*/
+#define QUEUE_PRIORITY_MAX              31U
+
+/* SEM_GETVALUE_EXISTS should be #defined if and only if the host OS supports
+sem_getvalue(). When sem_getvalue() is implemented, posix_ipc enables
+the `value` attribute on Semaphore instances. (It's not supported on Mac.)
+*/
+#define SEM_GETVALUE_EXISTS
+
+/* SEM_TIMEDWAIT_EXISTS should be #defined if and only if the host OS supports
+sem_timedwait(). When sem_timedwait() is implemented, posix_ipc enables
+non-infinite timeouts for acquire() on Semaphore instances.
+(It's not supported on Mac.)
+*/
+#define SEM_TIMEDWAIT_EXISTS
+
+/* SEM_VALUE_MAX is the maximum value of a semaphore.
+
+This value only provides information to module users. The module reports it as
+posix_ipc.SEMAPHORE_VALUE_MAX, but that value isn't used anywhere in the
+module code, so if it's wrong, that might not matter to you.
+
+SEM_VALUE_MAX is already #defined in system header files on many systems, so
+it should be surrounded with #ifndef/#endif here.
+*/
+#ifndef SEM_VALUE_MAX
+#define SEM_VALUE_MAX                   32767
+#endif


### PR DESCRIPTION
 - Add `system_info.sample.h` which thoroughly documents the header file contents. Some of this content was moved from `building.md`
 - Update `building.md` to clarify the role of `system_info.h` and how to write your own.