### PR TITLE
Fix MANIFEST.in for `src` directory

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,9 @@
 include INSTALL LICENSE VERSION
-include README.md USAGE.md history.md
-include src/posix_ipc_module.c
+include README.md USAGE.md history.md building.md
+include system_info.sample.h
+# The 'graft src' command has the useful flexibility of copying a custom
+# system_info.h if one exists, and not fussing if there isn't one present.
+graft src
 graft build_support
 graft tests
 # I use recursive-include instead of graft so that I don't accidentally

--- a/building.md
+++ b/building.md
@@ -6,9 +6,9 @@ You can build `posix_ipc` with a normal build command like `python -m build`. If
 
 `posix_ipc` needs to know various IPC-related facts about its host system. For instance, some operating systems don't offer a timed wait function for semaphores. This module wants to make that functionality available when it's present, and also needs to know when it's _not_ present and therefore can't be used.
 
-This kind of information needs to be known before `posix_ipc` is compiled. To get that information, `build_support/discover_system_info.py` runs when `setup.py` is invoked. (In `posix_ipc` releases prior to 1.2, this script was called `prober.py`.)
+This kind of information needs to be known before `posix_ipc` is compiled. To get that information, `build_support/discover_system_info.py` runs when `setup.py` is invoked. (In `posix_ipc` releases prior to 1.2.0, this script was called `prober.py`.)
 
-The goal of `discover_system_info.py` is to write a C header file called `src/system_info.h`. (In `posix_ipc` releases prior to 1.2, this file was called `probe_results.h`.) This header file isn't part of the source distribution, nor should it be. It contains values that are specific to the system on which `posix_ipc` is built.
+The goal of `discover_system_info.py` is to write a C header file called `src/system_info.h`. (In `posix_ipc` releases prior to 1.2.0, this file was called `probe_results.h`.) This header file isn't part of the source distribution, nor should it be. It contains values that are specific to the system on which `posix_ipc` is built.
 
 ## The System Info Header File
 


### PR DESCRIPTION
This is another attempt to fix #82. The subtle change to `graft src` in `MANIFEST.in` instead of explicitly listing files means should fix #82 (per the new comment in `MANIFEST.in`). 

Bonus fixes --

 - Add `building.md` and `system_info.sample.h` to `MANIFEST.in` so that they're included in the source distro
 - Minor touch up to version number mentions in `building.md`