### PR TITLE
build_support: fix cross-compilation error when CC is a multi-part co…

### DIFF
--- a/build_support/discover_system_info.py
+++ b/build_support/discover_system_info.py
@@ -1,6 +1,7 @@
 import subprocess
 import platform
 import os
+import shlex
 
 # Set these to None for compile/link debugging or subprocess.PIPE to silence
 # compiler warnings and errors.
@@ -49,7 +50,9 @@ def does_build_succeed(filename, linker_options=""):
     #   - Some versions of Linux place the sem_xxx() functions in libpthread.
     #     Rather than testing whether or not it's needed, I just specify it
     #     everywhere since it's harmless to specify it when it's not needed.
-    cmd = [os.getenv("CC", "cc"),
+    cc = os.getenv("CC", "cc")
+    cmd = [
+           *shlex.split(cc),
            '-Wall',
            '-o',
            f'./build_support/src/{filename[:-2]}',


### PR DESCRIPTION
…mmand

Fix the following error when cross-compiling with an environment-defined CC that includes flags:

FileNotFoundError: [Errno 2] No such file or directory: 'x86_64-wrs-linux-gcc -m64 -march=nehalem -mtune=generic -mfpmath=sse -msse4.2 -fstack-protector-strong  -O2 -D_FORTIFY_SOURCE=2 -Wformat -Wformat-security -Werror=format-security
--sysroot=/build-1.3.0/tmp/work/corei7-64-wrs-linux/python3-posix-ipc/1.3.0/recipe-sysroot'

This happened because the CC environment variable was treated as a single string instead of being split into arguments. The fix uses shlex.split() to correctly parse CC into a list of compiler and flags, and then unpacks it when forming the subprocess command.